### PR TITLE
Game Library Cell Title UILabels: Tightening up details for balance.

### DIFF
--- a/Provenance/Game Library/PVGameLibraryCollectionViewCell.m
+++ b/Provenance/Game Library/PVGameLibraryCollectionViewCell.m
@@ -62,8 +62,9 @@ static const CGFloat LabelHeight = 44.0;
 #if !TARGET_OS_TV
 		_titleLabel.font=[_titleLabel.font fontWithSize:12];
 #endif
+		[_titleLabel setAllowsDefaultTighteningForTruncation:YES];
 		[_titleLabel setAdjustsFontSizeToFitWidth:YES];
-		[_titleLabel setMinimumScaleFactor:0.75];
+		[_titleLabel setMinimumScaleFactor:0.85];
 
         if ([[PVSettingsModel sharedInstance] showGameTitles]) {
             [[self contentView] addSubview:_titleLabel];


### PR DESCRIPTION
.75 scaled min felt a bit too small for balance -> added ability to tighten spacing before truncating, bumped min scaling up to .85 - checked against large sample to see how titles feel and looking pretty good.